### PR TITLE
Change signature to maq(reward, cost, DR.scores, budget = NULL, ...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ eval.forest <- grf::multi_arm_causal_forest(X[test, ], Y[test], W[test])
 DR.scores <- grf::get_scores(eval.forest, drop = TRUE)
 
 # Fit a Qini curve on evaluation data, using 200 bootstrap replicates for confidence intervals.
-max.budget <- 1
-ma.qini <- maq(tau.hat, cost, max.budget, DR.scores, R = 200)
+ma.qini <- maq(tau.hat, cost, DR.scores, R = 200)
 
 # Plot the Qini curve.
 plot(ma.qini)
@@ -70,7 +69,7 @@ pi.mat <- predict(ma.qini, spend = 0.2)
 # evaluation via AIPW scores is to use inverse-propensity weighting (IPW).
 W.hat <- rep(1/3, 3)
 IPW.scores <- get_ipw_scores(Y[test], W[test], W.hat)
-mq.ipw <- maq(tau.hat, cost, max.budget, IPW.scores)
+mq.ipw <- maq(tau.hat, cost, IPW.scores)
 ```
 
 ### Details

--- a/experiments/swaw/figure_1.R
+++ b/experiments/swaw/figure_1.R
@@ -4,7 +4,6 @@ source("generate_data.R")
 library(maq)
 library(grf)
 
-max.budget = 100
 n = 5000
 p = 10
 data.train = generate_data(n, p)
@@ -25,10 +24,10 @@ cf.eval = multi_arm_causal_forest(
 dr.eval = get_scores(cf.eval, drop = TRUE)
 cost.eval = data.eval$cost
 
-mq = maq(tau.hat.eval, cost.eval, max.budget, dr.eval, R = 200)
-mq.1 = maq(tau.hat.eval[, 1], cost.eval[, 1], max.budget, dr.eval[, 1], R = 200)
-mq.2 = maq(tau.hat.eval[, 2], cost.eval[, 2], max.budget, dr.eval[, 2], R = 200)
-mq.r = maq(tau.hat.eval, cost.eval, max.budget, dr.eval, target.with.covariates = FALSE, R = 200)
+mq = maq(tau.hat.eval, cost.eval, dr.eval, R = 200)
+mq.1 = maq(tau.hat.eval[, 1], cost.eval[, 1], dr.eval[, 1], R = 200)
+mq.2 = maq(tau.hat.eval[, 2], cost.eval[, 2], dr.eval[, 2], R = 200)
+mq.r = maq(tau.hat.eval, cost.eval, dr.eval, target.with.covariates = FALSE, R = 200)
 
 pdf("figure_1.pdf")
 plot(mq, lwd = 2, ci.args = NULL)

--- a/experiments/swaw/figure_targeting.R
+++ b/experiments/swaw/figure_targeting.R
@@ -58,7 +58,6 @@ generate_data = function(n) {
   list(X = X, Y = Y, W = W, cost = cost, cost.oracle = cost_oracle, tau = tau)
 }
 
-max.budget = 10
 n_eval = 1500
 data.eval = generate_data(n_eval)
 cf.eval = multi_arm_causal_forest(
@@ -71,17 +70,17 @@ dr.eval = get_scores(cf.eval, drop = TRUE)
 data.eval$tau = matrix(rnorm(n_eval*3,0,1.2),n_eval, 3) + data.eval$tau
 data.eval$cost.oracle = pmax(matrix(0.001, n_eval,3), matrix(rnorm(n_eval*3,0,1.2),n_eval, 3) + data.eval$cost.oracle)
 
-mq = maq(data.eval$tau, data.eval$cost.oracle, max.budget, dr.eval)
-mq.1 = maq(data.eval$tau[, 1], data.eval$cost.oracle[,1], max.budget, dr.eval[, 1])
-mq.2 = maq(data.eval$tau[, 2], data.eval$cost.oracle[,2], max.budget, dr.eval[, 2])
-mq.3 = maq(data.eval$tau[, 3], data.eval$cost.oracle[,3], max.budget, dr.eval[, 3])
-mq.12 = maq(data.eval$tau[, c(1,2)], data.eval$cost.oracle[,c(1,2)], max.budget, dr.eval[, c(1,2)])
-mq.13 = maq(data.eval$tau[, c(1,3)], data.eval$cost.oracle[,c(1,3)], max.budget, dr.eval[, c(1,3)])
-mq.23 = maq(data.eval$tau[, c(2,3)], data.eval$cost.oracle[,c(2,3)], max.budget, dr.eval[, c(2,3)])
-mq.random = maq(data.eval$tau, data.eval$cost.oracle, max.budget, dr.eval, target.with.covariates = FALSE)
-mq.random1 = maq(data.eval$tau[, 1], data.eval$cost.oracle[, 1], max.budget, dr.eval[,1], target.with.covariates = FALSE)
-mq.random2 = maq(data.eval$tau[, 2], data.eval$cost.oracle[, 2], max.budget, dr.eval[,2], target.with.covariates = FALSE)
-mq.random3 = maq(data.eval$tau[, 3], data.eval$cost.oracle[, 3], max.budget, dr.eval[,3], target.with.covariates = FALSE)
+mq = maq(data.eval$tau, data.eval$cost.oracle, dr.eval)
+mq.1 = maq(data.eval$tau[, 1], data.eval$cost.oracle[,1], dr.eval[, 1])
+mq.2 = maq(data.eval$tau[, 2], data.eval$cost.oracle[,2], dr.eval[, 2])
+mq.3 = maq(data.eval$tau[, 3], data.eval$cost.oracle[,3], dr.eval[, 3])
+mq.12 = maq(data.eval$tau[, c(1,2)], data.eval$cost.oracle[,c(1,2)], dr.eval[, c(1,2)])
+mq.13 = maq(data.eval$tau[, c(1,3)], data.eval$cost.oracle[,c(1,3)], dr.eval[, c(1,3)])
+mq.23 = maq(data.eval$tau[, c(2,3)], data.eval$cost.oracle[,c(2,3)], dr.eval[, c(2,3)])
+mq.random = maq(data.eval$tau, data.eval$cost.oracle, dr.eval, target.with.covariates = FALSE)
+mq.random1 = maq(data.eval$tau[, 1], data.eval$cost.oracle[, 1], dr.eval[,1], target.with.covariates = FALSE)
+mq.random2 = maq(data.eval$tau[, 2], data.eval$cost.oracle[, 2], dr.eval[,2], target.with.covariates = FALSE)
+mq.random3 = maq(data.eval$tau[, 3], data.eval$cost.oracle[, 3], dr.eval[,3], target.with.covariates = FALSE)
 
 
 # Panel A

--- a/experiments/swaw/table_sim.R
+++ b/experiments/swaw/table_sim.R
@@ -5,7 +5,6 @@ library(maq)
 library(grf)
 library(xtable)
 
-max.budget = 100
 p = 10
 
 # Generate "truth" test data
@@ -23,7 +22,7 @@ cf.train = multi_arm_causal_forest(
 # "population" quantities
 tau.true = predict(cf.train, data.truth$X, drop = TRUE)$predictions
 cost.true = data.truth$cost
-mq.true = maq(tau.true, cost.true, max.budget, data.truth$tau)
+mq.true = maq(tau.true, cost.true, data.truth$tau)
 gain.true = unlist(lapply(spends, function(s) average_gain(mq.true, s)[["estimate"]]))
 
 res = list()
@@ -39,7 +38,7 @@ for (n in c(1000, 2000, 5000, 10000)) {
     )
     dr.eval = get_scores(cf.eval, drop = TRUE)
     cost.eval = data.eval$cost
-    mq = maq(tau.hat.eval, cost.eval, max.budget, dr.eval, R = 200)
+    mq = maq(tau.hat.eval, cost.eval, dr.eval, R = 200)
 
     est = unlist(lapply(spends, function(s) average_gain(mq, s)[["estimate"]]))
     se = unlist(lapply(spends, function(s) average_gain(mq, s)[["std.err"]]))

--- a/experiments/swaw/table_sim_paired.R
+++ b/experiments/swaw/table_sim_paired.R
@@ -5,7 +5,6 @@ library(maq)
 library(grf)
 library(xtable)
 
-max.budget = 100
 p = 10
 
 # Generate "truth" test data
@@ -23,10 +22,10 @@ cf.train = multi_arm_causal_forest(
 # "population" quantities
 cost.true = data.truth$cost
 tau.true = predict(cf.train, data.truth$X, drop = TRUE)$predictions
-mq.true = maq(tau.true, cost.true, max.budget, data.truth$tau)
-mq1.true = maq(tau.true[, 1], cost.true[, 1], max.budget, data.truth$tau[, 1])
-mq2.true = maq(tau.true[, 2], cost.true[, 2], max.budget, data.truth$tau[, 2])
-mqr.true = maq(tau.true, cost.true, max.budget, data.truth$tau, target.with.covariates = FALSE)
+mq.true = maq(tau.true, cost.true, data.truth$tau)
+mq1.true = maq(tau.true[, 1], cost.true[, 1], data.truth$tau[, 1])
+mq2.true = maq(tau.true[, 2], cost.true[, 2], data.truth$tau[, 2])
+mqr.true = maq(tau.true, cost.true, data.truth$tau, target.with.covariates = FALSE)
 
 gain.true = unlist(lapply(spends, function(s) average_gain(mq.true, s)[["estimate"]]))
 gain1.true = unlist(lapply(spends, function(s) average_gain(mq1.true, s)[["estimate"]]))
@@ -50,10 +49,10 @@ for (n in c(1000, 2000, 5000, 10000)) {
 
     # fit maq
     cost.eval = data.eval$cost
-    mq = maq(tau.hat.eval, cost.eval, max.budget, dr.eval, R = 200)
-    mq1 = maq(tau.hat.eval[, 1], cost.eval[, 1], max.budget, dr.eval[, 1], R = 200)
-    mq2 = maq(tau.hat.eval[, 2], cost.eval[, 2], max.budget, dr.eval[, 2], R = 200)
-    mqr = maq(tau.hat.eval, cost.eval, max.budget, dr.eval, R = 200, target.with.covariates = FALSE)
+    mq = maq(tau.hat.eval, cost.eval, dr.eval, R = 200)
+    mq1 = maq(tau.hat.eval[, 1], cost.eval[, 1], dr.eval[, 1], R = 200)
+    mq2 = maq(tau.hat.eval[, 2], cost.eval[, 2], dr.eval[, 2], R = 200)
+    mqr = maq(tau.hat.eval, cost.eval, dr.eval, R = 200, target.with.covariates = FALSE)
 
     est.all.r = unlist(lapply(spends, function(s) difference_gain(mq, mqr, s)[["estimate"]]))
     se.all.r = unlist(lapply(spends, function(s) difference_gain(mq, mqr, s)[["std.err"]]))

--- a/experiments/swaw/timing.R
+++ b/experiments/swaw/timing.R
@@ -10,7 +10,7 @@ reward.eval = matrix(runif(n * K), n, K)
 cost = 0.05 + matrix(runif(n * K), n, K)
 
 print(microbenchmark(
-  mq <- maq(reward, cost, 1e5, cost, R = 0),
+  mq <- maq(reward, cost, cost, R = 0),
   times = 100,
   unit = "seconds"
 ), digits = 2)

--- a/experiments/swaw/voting.R
+++ b/experiments/swaw/voting.R
@@ -52,14 +52,13 @@ Y.k.ipw.eval = Y.k.ipw[eval, -1] - Y.k.ipw[eval, 1]
 
 # Fit cost curves
 cost = c(1, 15, 30, 45)
-max.budget = 100
-mq = maq(tau.hat.eval, cost, max.budget, Y.k.ipw.eval, clusters = cluster[eval], R = 200)
-mq.civic = maq(tau.hat.eval[, 1], cost[1], max.budget, Y.k.ipw.eval[, 1], clusters = cluster[eval], R = 200)
-mq.hawthorne = maq(tau.hat.eval[, 2], cost[2], max.budget, Y.k.ipw.eval[, 2], clusters = cluster[eval], R = 200)
-mq.self = maq(tau.hat.eval[, 3], cost[3], max.budget, Y.k.ipw.eval[, 3], clusters = cluster[eval], R = 200)
-mq.neighbors = maq(tau.hat.eval[, 4], cost[4], max.budget, Y.k.ipw.eval[, 4], clusters = cluster[eval], R = 200)
+mq = maq(tau.hat.eval, cost, Y.k.ipw.eval, clusters = cluster[eval], R = 200)
+mq.civic = maq(tau.hat.eval[, 1], cost[1], Y.k.ipw.eval[, 1], clusters = cluster[eval], R = 200)
+mq.hawthorne = maq(tau.hat.eval[, 2], cost[2], Y.k.ipw.eval[, 2], clusters = cluster[eval], R = 200)
+mq.self = maq(tau.hat.eval[, 3], cost[3], Y.k.ipw.eval[, 3], clusters = cluster[eval], R = 200)
+mq.neighbors = maq(tau.hat.eval[, 4], cost[4], Y.k.ipw.eval[, 4], clusters = cluster[eval], R = 200)
 # Non-targeting baseline
-mq.avg = maq(tau.hat.eval, cost, max.budget, Y.k.ipw.eval, clusters = cluster[eval], R = 200, target.with.covariates = FALSE)
+mq.avg = maq(tau.hat.eval, cost, Y.k.ipw.eval, clusters = cluster[eval], R = 200, target.with.covariates = FALSE)
 
 
 spend = 5

--- a/r-package/maq/man/maq.Rd
+++ b/r-package/maq/man/maq.Rd
@@ -7,8 +7,8 @@
 maq(
   reward,
   cost,
-  budget,
   DR.scores,
+  budget = NULL,
   target.with.covariates = TRUE,
   R = 0,
   paired.inference = TRUE,
@@ -28,10 +28,6 @@ measures the cost of assigning the i-th unit the k-th treatment arm.
 If the costs does not vary by unit, only by arm, this can also be a K-length vector.
 (Note: these costs need not be denominated on the same scale as the treatment effect estimates).}
 
-\item{budget}{The maximum spend per unit, \eqn{B_{max}}, to fit the Qini curve on.
-Setting this to some large number, such as \code{sum(cost)}, will fit the path up to a maximum spend per unit
-where each unit that is expected to benefit (that is, \eqn{\hat \tau(X_i)>0}) is treated.}
-
 \item{DR.scores}{An \eqn{n \cdot K} matrix of test set evaluation scores used to form an estimate of
 Q(B). With known treatment propensities \eqn{P[W_i|X_i]},
 these scores can be constructed via inverse-propensity weighting, i.e, with entry (i, k) equal to
@@ -39,6 +35,10 @@ these scores can be constructed via inverse-propensity weighting, i.e, with entr
 In observational settings where \eqn{P[W_i|X_i]} has to be estimated, then an alternative is to
 construct these scores via augmented inverse-propensity weighting (AIPW) - yielding a doubly
 robust estimate of the Qini curve (for details, see the paper).}
+
+\item{budget}{The maximum spend per unit, \eqn{B_{max}}, to fit the Qini curve on.
+Setting this to NULL (Default), will fit the path up to a maximum spend per unit
+where each unit that is expected to benefit (that is, \eqn{\hat \tau_k(X_i)>0}) is treated.}
 
 \item{target.with.covariates}{If TRUE (Default), then the policy \eqn{\pi_B} takes covariates
 \eqn{X_i} into account. If FALSE, then the policy only takes the average reward
@@ -127,8 +127,7 @@ eval.forest <- grf::multi_arm_causal_forest(X[test, ], Y[test], W[test])
 DR.scores <- grf::get_scores(eval.forest, drop = TRUE)
 
 # Fit a Qini curve on evaluation data, using 200 bootstrap replicates for confidence intervals.
-max.budget <- 1
-ma.qini <- maq(tau.hat, cost, max.budget, DR.scores, R = 200)
+ma.qini <- maq(tau.hat, cost, DR.scores, R = 200)
 
 # Plot the Qini curve.
 plot(ma.qini)
@@ -144,20 +143,20 @@ pi.mat <- predict(ma.qini, spend = 0.2)
 # evaluation via AIPW scores is to use inverse-propensity weighting (IPW).
 W.hat <- rep(1/3, 3)
 IPW.scores <- get_ipw_scores(Y[test], W[test], W.hat)
-mq.ipw <- maq(tau.hat, cost, max.budget, IPW.scores)
+mq.ipw <- maq(tau.hat, cost, IPW.scores)
 
 plot(mq.ipw, add = TRUE, col = 2)
 legend("topleft", c("All arms", "95\% CI", "All arms (IPW)"), col = c(1, 1, 2), lty = c(1, 3, 1))
 
 # Estimate some baseline policies.
 # a) A policy that ignores covariates and only takes the average reward/cost into account.
-qini.avg <- maq(tau.hat, cost, max.budget, DR.scores, target.with.covariates = FALSE, R = 200)
+qini.avg <- maq(tau.hat, cost, DR.scores, target.with.covariates = FALSE, R = 200)
 
 # b) A policy that only use arm 1.
-qini.arm1 <- maq(tau.hat[, 1], cost[, 1], max.budget, DR.scores[, 1], R = 200)
+qini.arm1 <- maq(tau.hat[, 1], cost[, 1], DR.scores[, 1], R = 200)
 
 # c) A policy that only use arm 2.
-qini.arm2 <- maq(tau.hat[, 2], cost[, 2], max.budget, DR.scores[, 2], R = 200)
+qini.arm2 <- maq(tau.hat[, 2], cost[, 2], DR.scores[, 2], R = 200)
 
 plot(ma.qini, ci.args = NULL)
 plot(qini.avg, col = 2, add = TRUE, ci.args = NULL)

--- a/r-package/maq/man/predict.maq.Rd
+++ b/r-package/maq/man/predict.maq.Rd
@@ -46,7 +46,7 @@ K <- 4
 reward <- matrix(rnorm(n * K), n, K)
 cost <- matrix(runif(n * K), n, K)
 DR.scores <- reward + rnorm(n)
-path <- maq(reward, cost, 1, DR.scores)
+path <- maq(reward, cost, DR.scores)
 
 # Get the treatment allocation matrix
 pi.mat <- predict(path, 0.1)

--- a/r-package/maq/tests/benchmarks/benchmark.R
+++ b/r-package/maq/tests/benchmarks/benchmark.R
@@ -11,14 +11,13 @@ parallel::detectCores()
 # [1] 8
 
 # 1 medium n medium K
-budget = 1e9
 n = 1e5
 K = 10
 reward = matrix(1 + rnorm(n*K), n, K)
 cost = 0.05 + matrix(runif(n*K), n, K)
 
 b1 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 200, paired.inference = FALSE),
   times = 10,
   unit = "seconds"
 )
@@ -30,7 +29,7 @@ reward = matrix(1 + rnorm(n*K), n, K)
 cost = 0.05 + matrix(runif(n*K), n, K)
 
 b2 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 200, paired.inference = FALSE),
   times = 10,
   unit = "seconds"
 )
@@ -42,7 +41,7 @@ reward = matrix(1 + rnorm(n*K), n, K)
 cost = 0.05 + matrix(runif(n*K), n, K)
 
 b3 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 200, paired.inference = FALSE),
   times = 5,
   unit = "seconds"
 )
@@ -54,13 +53,13 @@ reward = matrix(1 + rnorm(n*K), n, K)
 cost = 0.05 + matrix(runif(n*K), n, K)
 
 b41 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 0, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 0, paired.inference = FALSE),
   times = 10,
   unit = "seconds"
 )
 
 b42 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 200, paired.inference = FALSE),
   times = 10,
   unit = "seconds"
 )
@@ -72,7 +71,7 @@ reward = matrix(1 + rnorm(n*K), n, K)
 cost = 0.05 + matrix(runif(n*K), n, K)
 
 b5 <- microbenchmark(
-  maq(reward, cost, budget, reward, R = 0, paired.inference = FALSE),
+  maq(reward, cost, reward, R = 0, paired.inference = FALSE),
   times = 5,
   unit = "seconds"
 )
@@ -90,29 +89,29 @@ print(list(b1,b2,b3,b41,b42,b5), digits = 3)
 # [[1]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE) 1.93 1.97    2   1.99 2.02 2.12    10
+# maq(reward, cost, reward, R = 200, paired.inference = FALSE) 1.93 1.97    2   1.99 2.02 2.12    10
 #
 # [[2]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE) 3.84 3.85 3.87   3.87 3.89 3.92    10
+# maq(reward, cost, reward, R = 200, paired.inference = FALSE) 3.84 3.85 3.87   3.87 3.89 3.92    10
 #
 # [[3]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE) 15.3 15.3 15.4   15.3 15.3 15.8     5
+# maq(reward, cost, reward, R = 200, paired.inference = FALSE) 15.3 15.3 15.4   15.3 15.3 15.8     5
 #
 # [[4]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 0, paired.inference = FALSE) 1.91 1.92 1.94   1.93 1.95 2.01    10
+# maq(reward, cost, reward, R = 0, paired.inference = FALSE) 1.91 1.92 1.94   1.93 1.95 2.01    10
 #
 # [[5]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 200, paired.inference = FALSE) 31.7 31.8 32.9   32.1 32.4 40.7    10
+# maq(reward, cost, reward, R = 200, paired.inference = FALSE) 31.7 31.8 32.9   32.1 32.4 40.7    10
 #
 # [[6]]
 # Unit: seconds
 # expr  min   lq mean median   uq  max neval
-# maq(reward, cost, budget, reward, R = 0, paired.inference = FALSE) 10.2 10.2 10.2   10.2 10.2 10.2     5
+# maq(reward, cost, reward, R = 0, paired.inference = FALSE) 10.2 10.2 10.2   10.2 10.2 10.2     5

--- a/r-package/maq/tests/testthat/test_LP.R
+++ b/r-package/maq/tests/testthat/test_LP.R
@@ -36,7 +36,7 @@ test_that("gain solution path is same as LP solution (small problem)", {
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
 
-  mqini <- maq(reward, cost, budget, reward)
+  mqini <- maq(reward, cost, reward, budget)
   gain <- mqini[["_path"]]$gain
 
   lp.gain <- c()
@@ -55,7 +55,7 @@ test_that("solution is same as LP solution (fixed medium problem)", {
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
 
-  mqini <- maq(reward, cost, budget, reward)
+  mqini <- maq(reward, cost, reward, budget)
 
   ix <- length(mqini[["_path"]]$spend) - 1
   spend <- mqini[["_path"]]$spend[ix]
@@ -71,7 +71,7 @@ test_that("pi matrix is consistent with gain path", {
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
 
-  mqini <- maq(reward, cost, budget, reward)
+  mqini <- maq(reward, cost, reward, budget)
   gain <- mqini[["_path"]]$gain
 
   pi.gain <- c()
@@ -90,7 +90,7 @@ test_that("arbitrary points off gain path is same as LP", {
   reward <- matrix(0.1 + rnorm(n * K), n, K);
   cost <- matrix(0.05 + runif(n * K), n, K);
 
-  mqini <- maq(reward, cost, budget, reward)
+  mqini <- maq(reward, cost, reward, budget)
   spend.rng <- range(mqini[["_path"]]$spend)
   spends <- runif(25, spend.rng[1], spend.rng[2])
 
@@ -120,8 +120,8 @@ test_that("non-unique solution works as expected", {
   cost <- matrix(sample(c(1, 2), n * K, TRUE), n, K)
   spend <- 1
 
-  mq1 <- maq(reward, cost, budget, reward, R = 0)
-  mq2 <- maq(reward, cost, budget, reward, R = 0, tie.breaker = sample(1:n))
+  mq1 <- maq(reward, cost, reward, budget, R = 0)
+  mq2 <- maq(reward, cost, reward, budget, R = 0, tie.breaker = sample(1:n))
   lp <- lp_solver(reward, cost, spend)
   lp.reward <- sum(lp$alloc.mat * reward) / n
 
@@ -136,7 +136,7 @@ test_that("SEs capture LP re-solved", {
   reward <- matrix(rnorm(n * K), n, K)
   cost <- 0.05 + matrix(runif(n * K), n, K)
   R <- 500
-  mq <- maq(reward, cost, budget, reward, R = R)
+  mq <- maq(reward, cost, reward, budget, R = R)
 
   # pick an arbitrary spend point except the initial grid point
   sp <- sample(mq[["_path"]]$spend[-(1:3)], 1)
@@ -155,7 +155,7 @@ test_that("SEs capture LP re-solved", {
 
   # same, with clusters
   clusters <- rep(1:10, 10)
-  mq.cl <- maq(reward, cost, 100, reward, R = R, clusters = clusters)
+  mq.cl <- maq(reward, cost, reward, budget, R = R, clusters = clusters)
   mq.se.cl <- average_gain(mq.cl, sp)[[2]]
 
   samples.by.cluster <- split(seq_along(clusters), clusters)

--- a/r-package/maq/tests/testthat/test_interpolation.R
+++ b/r-package/maq/tests/testthat/test_interpolation.R
@@ -5,7 +5,7 @@ test_that("interpolated SEs work as expected", {
   K <- 10
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
-  mqini <- maq(reward, cost, budget, reward, R = 150, num.threads = 1, seed = 42)
+  mqini <- maq(reward, cost, reward, budget, R = 150, num.threads = 1, seed = 42)
   expect_equal(
     mqini$`_path`$std.err,
     c(0, 0.198695462698774, 0.312563012893381, 0.388774733803937)
@@ -17,7 +17,7 @@ test_that("interpolated SEs work as expected", {
   K <- 10
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
-  mqini <- maq(reward, cost, budget, reward, R = 150, num.threads = 1, seed = 42)
+  mqini <- maq(reward, cost, reward, budget, R = 150, num.threads = 1, seed = 42)
   expect_equal(
     mqini$`_path`$std.err,
     c(0, 0.198695462698774, 0.312563012893381, 0.331135893435333,
@@ -30,7 +30,7 @@ test_that("interpolated SEs work as expected", {
   K <- 10
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
-  mqini <- maq(reward, cost, budget, reward, R = 150, num.threads = 1, seed = 42)
+  mqini <- maq(reward, cost, reward, budget, R = 150, num.threads = 1, seed = 42)
   expect_equal(
     mqini$`_path`$std.err,
     numeric(0)
@@ -42,7 +42,7 @@ test_that("interpolated SEs work as expected", {
   K <- 10
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
-  mqini <- maq(reward, cost, budget, reward, R = 150, num.threads = 1, seed = 42)
+  mqini <- maq(reward, cost, reward, budget, R = 150, num.threads = 1, seed = 42)
   expect_equal(
     mqini$`_path`$std.err,
     c(0, 0.0011490908050312, 0.00203930403690631, 0.00334682530653467,
@@ -372,7 +372,7 @@ test_that("interpolated SEs work as expected", {
   K <- 10
   reward <- matrix(1 + 2 * runif(n * K), n, K);
   cost <- matrix(runif(n * K), n, K);
-  mqini <- maq(reward, cost, budget, reward, R = 150, num.threads = 1, seed = 42)
+  mqini <- maq(reward, cost, reward, budget, R = 150, num.threads = 1, seed = 42)
   expect_equal(
     mqini$`_path`$std.err,
     c(0, 0.00047330342265862, 0.00151505540370292, 0.00277547146075833,

--- a/r-package/maq/tests/valgrind/test_maq_valgrind.R
+++ b/r-package/maq/tests/valgrind/test_maq_valgrind.R
@@ -2,7 +2,6 @@
 # Usage:
 # R -d "valgrind --tool=memcheck --leak-check=full" --vanilla  < test_maq_valgrind.R
 library(maq)
-budget <- 1000
 n <- 1500
 K <- 10
 reward <- matrix(0.1 + rnorm(n * K), n, K)
@@ -11,6 +10,6 @@ cost <- 0.05 + matrix(runif(n * K), n, K)
 wts <- runif(n)
 clust <- sample(1:250, n, TRUE)
 
-mq <- maq(reward, cost, budget, reward.eval, sample.weights = wts, clusters = clust, R = 200)
+mq <- maq(reward, cost, reward.eval, sample.weights = wts, clusters = clust, R = 200)
 
-mqr <- maq(reward, cost, budget, reward.eval, sample.weights = wts, clusters = clust, R = 200, target.with.covariates = FALSE)
+mqr <- maq(reward, cost, reward.eval, sample.weights = wts, clusters = clust, R = 200, target.with.covariates = FALSE)


### PR DESCRIPTION
The original design of forcing the user to select a budget in the call

`maq(reward, cost, budget, DR.scores, ...etc)` 

was a bit unfortunate as it would require you to think extra when fitting/experimenting with curves with various cost structures and you just wanted them fit up until a maximum budget where each unit expected to benefit, is treated.

We do this breaking change now, making `budget` an optional argument, which by default just fits the curve to the budget point where we treat all units with positive $\hat \tau_k(X_i)$.