### PR TITLE
Fix a grid lookup in integrated_difference

### DIFF
--- a/r-package/maq/R/maq.R
+++ b/r-package/maq/R/maq.R
@@ -511,9 +511,12 @@ integrated_difference <- function(object.lhs,
       estimate <- mean(gain.path, na.rm = TRUE) + area.offset
     } else {
       interp.ratio <- (spend - spend.grid[path.idx]) / (spend.grid[path.idx + 1] - spend.grid[path.idx])
-      estimate <- (sum(gain.path[1:path.idx], na.rm = TRUE) +
-          gain.path[path.idx] + (gain.path[path.idx + 1] - gain.path[path.idx]) * interp.ratio) /
-            (path.idx + 1)
+      adj <- if (interp.ratio < 1e-10) {
+        NA
+      } else {
+        gain.path[path.idx] + (gain.path[path.idx + 1] - gain.path[path.idx]) * interp.ratio
+      }
+      estimate <- mean(c(gain.path[1:path.idx], adj), na.rm = TRUE)
     }
 
     estimate

--- a/r-package/maq/tests/testthat/test_maq.R
+++ b/r-package/maq/tests/testthat/test_maq.R
@@ -506,3 +506,23 @@ test_that("integrated_difference works as expected", {
     mean(unlist(lapply(s, function(x) average_gain(mq2, x)[[1]])))
   expect_equal(est[[1]], auc.naive, tolerance = 0.005)
 })
+
+test_that("integrated_difference grid lookup numerics works as expected", {
+  n <- 100
+  K <- 1
+  reward1 <- matrix(1 + runif(n*K), n, K)
+  reward2 <- matrix(1 + runif(n*K), n, K)
+  reward.scores <- matrix(1 + rnorm(n*K), n, K)
+  cost <- 1
+
+  q1 <- maq(reward1, cost, reward.scores)
+  q2 <- maq(reward2, cost, reward.scores)
+  sgrid <- seq(1/n, 1, length.out = n)
+
+  est <- unlist(lapply(sgrid, function(s) integrated_difference(q1, q2, s)[[1]]))
+  estt <- unlist(lapply(seq_along(sgrid), function(i) {
+    mean(q1[["_path"]]$gain[1:i]) - mean(q2[["_path"]]$gain[1:i])
+  }))
+
+  expect_equal(est, estt, tolerance = 1e-10)
+})


### PR DESCRIPTION
This is related to numerical problems indexing into a grid by binary search, average_gain avoids works this out by having the inner interval as the last condition and having the ~0 delta resolved by interp.ratio being ~0. integrated_difference needs a slightly different condition.

This has negligible effect on the output of integrated_difference, this fix may change previous results on order of 1/n